### PR TITLE
Fix bug #33

### DIFF
--- a/includes/google/google.php
+++ b/includes/google/google.php
@@ -1,6 +1,10 @@
 <?php
   require_once('includes/google/GoogleAuth.php');
 
+  // Accept clock skew between your server and the Google server of 10 seconds
+  use \Firebase\JWT\JWT;
+  JWT::$leeway = 10;
+
   $google_client = new Google_Client;
   $google_auth = new GoogleAuth($google_client);
 ?>


### PR DESCRIPTION
Fixed bug #33 

If the error is still occurring, increase the leeway in [`includes/google/google.php`](https://github.com/jr-cologne/login-script/blob/jr_fix-bug-%2333/includes/google/google.php).

Example:
```php
// Accept clock skew between your server and the Google server of 20 seconds
use \Firebase\JWT\JWT;
JWT::$leeway = 20;
```